### PR TITLE
Fixed licences date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2019-2020 Teserakt AG
+   Copyright 2019 Teserakt AG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commands.go
+++ b/commands.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/const.go
+++ b/crypto/const.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/hash_test.go
+++ b/crypto/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/validators.go
+++ b/crypto/validators.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crypto/validators_test.go
+++ b/crypto/validators_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/json.go
+++ b/keys/json.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/json_test.go
+++ b/keys/json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/publickey.go
+++ b/keys/publickey.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/publickey_test.go
+++ b/keys/publickey_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/symmetric.go
+++ b/keys/symmetric.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/symmetric_test.go
+++ b/keys/symmetric_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/keys/types.go
+++ b/keys/types.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019-2020 Teserakt AG
+// Copyright 2019 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
From comment https://github.com/teserakt-io/e4go/pull/20#discussion_r359456945, updated licences dates to be only current year.