### PR TITLE
README: add Godoc badge for easy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![alt text](logo.png)
 
+[![GoDoc][godoc-image]][godoc-url]
+
 - [Introduction](#introduction)
 - [Using our client application](#using-our-client-application)
 - [Creating a client](#creating-a-client)
@@ -235,3 +237,6 @@ To request support, please contact [team@teserakt.io](mailto:team@teserakt.io).
 ## Intellectual property
 
 e4go is copyright (c) Teserakt AG 2018-2020, and released under Apache 2.0 License (see [LICENCE](./LICENSE)).
+
+[godoc-image]: https://godoc.org/github.com/teserakt-io/e4go?status.svg
+[godoc-url]: https://godoc.org/github.com/teserakt-io/e4go


### PR DESCRIPTION
To help with easy navigation of the API and
always being able to access the Godoc.

### Before
<img width="971" alt="Screen Shot 2020-01-27 at 7 21 24 AM" src="https://user-images.githubusercontent.com/4898263/73150111-a6de0000-40d5-11ea-9a57-2006c9325a2f.png">

### After
<img width="1019" alt="Screen Shot 2020-01-27 at 7 19 53 AM" src="https://user-images.githubusercontent.com/4898263/73150067-6f6f5380-40d5-11ea-843c-e35036360112.png">
