### PR TITLE
Storage abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Depending on the mode, different functions should be used to instantiate a clien
 
 ### Symmetric-key client
 
-A symmetric-key client can be created from a 16-byte identifier (type `[]byte`), a 32-byte key (type `[]byte`), and an `e4.Store` implementation, which will be used to store the client's state (see [client storage](#client-storage) section for details):
+A symmetric-key client can be created from a 16-byte identifier (type `[]byte`), a 32-byte key (type `[]byte`), and an `e4.ReadWriteSeeker` implementation, used to persist the client's state (see [client storage](#client-storage) section for details):
 
 ```go
     client, err := e4.NewClient(&e4.SymIDAndKey{ID: id, Key: key}, store)
@@ -69,7 +69,7 @@ The latter is a wrapper over `NewSymKeyClient()` that creates the ID by hashing 
 
 ### Public-key client
 
-A public-key client can be created from a 16-byte identifier (type `[]byte`), an Ed25519 private key (type `ed25519.PrivateKey`), an `e4.Store` implementation, which will be used to store the client's state (see [client storage](#client-storage) section for details), and a Curve25519 public key (32-byte `[]byte`):
+A public-key client can be created from a 16-byte identifier (type `[]byte`), an Ed25519 private key (type `ed25519.PrivateKey`), an `e4.ReadWriteSeeker` implementation, which will be used to store the client's state (see [client storage](#client-storage) section for details), and a Curve25519 public key (32-byte `[]byte`):
 
 ```go
 client, err := e4.NewClient(&e4.PubIDAndKey{ID:id, Key: key, C2PubKey: c2PubKey}, store)
@@ -93,7 +93,7 @@ pubKey, err := config.PubKey()
 
 ### From a saved state
 
-A client instance can be recovered using the `LoadClient()` helper, providing as argument an `e4.Store` implementation:
+A client instance can be recovered using the `LoadClient()` helper given an `e4.ReadWriteSeeker` implementation::
 
 ```go
     client, err := e4.LoadClient(store)
@@ -103,7 +103,7 @@ Note that a client's state is automatically saved to the provided store when the
 
 ### Client storage
 
-E4 client offer a way to persist its internal state, allowing to shut it down and reload without having to retransmit all the keys, by providing an `e4.Store` implementation to the client. This interface is compatible with any [io.ReadWriteSeeker](https://godoc.org/io#ReadWriteSeeker), such as the `os.File` type, which should be the most common option. But it also allows custom implementations for platforms where filesystem isn't available, like the `e4.NewMemoryStore([]byte)` we provide.
+E4 client offer a way to persist its internal state, allowing to shut it down and reload without having to retransmit all the keys, by providing an `e4.ReadWriteSeeker` implementation to the client. This interface is compatible with any [io.ReadWriteSeeker](https://godoc.org/io#ReadWriteSeeker), such as the `os.File` type, which should be the most common option. But it also allows custom implementations for platforms where filesystem isn't available, like the `e4.NewMemoryStore([]byte)` we provide.
 
 ## Integration instructions
 
@@ -232,9 +232,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 
-import io.teserakt.e4.Store;
+import io.teserakt.e4.ReadWriteSeeker;
 
-public class FileStore implements Store {
+public class FileStore implements ReadWriteSeeker {
     private static final int SEEK_START = 0;
     private static final int SEEK_CURRENT = 1;
     private static final int SEEK_END = 2;

--- a/client.go
+++ b/client.go
@@ -290,7 +290,9 @@ func LoadClient(store ReadWriteSeeker) (Client, error) {
 		return nil, err
 	}
 
-	store.Seek(0, io.SeekStart)
+	if _, err := store.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
 
 	c.store = store
 
@@ -299,13 +301,15 @@ func LoadClient(store ReadWriteSeeker) (Client, error) {
 
 func (c *client) save() error {
 	encoder := json.NewEncoder(c.store)
-	err := encoder.Encode(c)
-	if err != nil {
+	if err := encoder.Encode(c); err != nil {
 		log.Printf("failed to save client: %v", err)
 		return err
 	}
 
-	c.store.Seek(0, io.SeekStart)
+	if _, err := c.store.Seek(0, io.SeekStart); err != nil {
+		log.Printf("failed to save client: %v", err)
+		return err
+	}
 
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -249,7 +249,7 @@ func (np *PubNameAndPassword) PubKey() (e4crypto.Ed25519PublicKey, error) {
 // depending the given ClientConfig
 //
 // config is a ClientConfig, either SymIDAndKey, SymNameAndPassword, PubIDAndKey or PubNameAndPassword
-// store is a n Store
+// store is an e4.Store implementation
 func NewClient(config ClientConfig, store Store) (Client, error) {
 	return config.genNewClient(store)
 }

--- a/client.go
+++ b/client.go
@@ -40,8 +40,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
-	"os"
 	"sync"
 	"time"
 
@@ -115,17 +115,17 @@ type client struct {
 
 	Key keys.KeyMaterial
 
-	FilePath       string
 	ReceivingTopic string
 
-	lock sync.RWMutex
+	store io.WriteSeeker
+	lock  sync.RWMutex
 }
 
 var _ Client = (*client)(nil)
 
 // ClientConfig defines an interface for client configuration
 type ClientConfig interface {
-	genNewClient(persistStatePath string) (Client, error)
+	genNewClient(store io.WriteSeeker) (Client, error)
 }
 
 // SymIDAndKey defines a configuration to create an E4 client in symmetric key mode
@@ -165,7 +165,7 @@ var _ ClientConfig = (*SymNameAndPassword)(nil)
 var _ ClientConfig = (*PubIDAndKey)(nil)
 var _ ClientConfig = (*PubNameAndPassword)(nil)
 
-func (ik *SymIDAndKey) genNewClient(persistStatePath string) (Client, error) {
+func (ik *SymIDAndKey) genNewClient(store io.WriteSeeker) (Client, error) {
 	var newID []byte
 	if len(ik.ID) == 0 {
 		newID = e4crypto.RandomID()
@@ -179,10 +179,10 @@ func (ik *SymIDAndKey) genNewClient(persistStatePath string) (Client, error) {
 		return nil, fmt.Errorf("failed to created symkey from key: %v", err)
 	}
 
-	return newClient(newID, symKeyMaterial, persistStatePath)
+	return newClient(newID, symKeyMaterial, store)
 }
 
-func (np *SymNameAndPassword) genNewClient(persistStatePath string) (Client, error) {
+func (np *SymNameAndPassword) genNewClient(store io.WriteSeeker) (Client, error) {
 	id := e4crypto.HashIDAlias(np.Name)
 
 	key, err := e4crypto.DeriveSymKey(np.Password)
@@ -195,10 +195,10 @@ func (np *SymNameAndPassword) genNewClient(persistStatePath string) (Client, err
 		return nil, fmt.Errorf("failed to created symkey from key: %v", err)
 	}
 
-	return newClient(id, symKeyMaterial, persistStatePath)
+	return newClient(id, symKeyMaterial, store)
 }
 
-func (ik *PubIDAndKey) genNewClient(persistStatePath string) (Client, error) {
+func (ik *PubIDAndKey) genNewClient(store io.WriteSeeker) (Client, error) {
 	var newID []byte
 	if len(ik.ID) == 0 {
 		newID = e4crypto.RandomID()
@@ -212,10 +212,10 @@ func (ik *PubIDAndKey) genNewClient(persistStatePath string) (Client, error) {
 		return nil, fmt.Errorf("failed to create ed25519key from key: %v", err)
 	}
 
-	return newClient(newID, pubKeyMaterialKey, persistStatePath)
+	return newClient(newID, pubKeyMaterialKey, store)
 }
 
-func (np *PubNameAndPassword) genNewClient(persistStatePath string) (Client, error) {
+func (np *PubNameAndPassword) genNewClient(store io.WriteSeeker) (Client, error) {
 	id := e4crypto.HashIDAlias(np.Name)
 
 	key, err := e4crypto.Ed25519PrivateKeyFromPassword(np.Password)
@@ -228,7 +228,7 @@ func (np *PubNameAndPassword) genNewClient(persistStatePath string) (Client, err
 		return nil, fmt.Errorf("failed to create ed25519key from key: %v", err)
 	}
 
-	return newClient(id, pubKeyMaterialKey, persistStatePath)
+	return newClient(id, pubKeyMaterialKey, store)
 }
 
 // PubKey returns the ed25519.PublicKey derived from the password
@@ -251,12 +251,12 @@ func (np *PubNameAndPassword) PubKey() (e4crypto.Ed25519PublicKey, error) {
 //
 // config is a ClientConfig, either SymIDAndKey, SymNameAndPassword, PubIDAndKey or PubNameAndPassword
 // persistStatePath is the file system path to the file to read and persist the client's state.
-func NewClient(config ClientConfig, persistStatePath string) (Client, error) {
-	return config.genNewClient(persistStatePath)
+func NewClient(config ClientConfig, store io.WriteSeeker) (Client, error) {
+	return config.genNewClient(store)
 }
 
 // newClient creates a new client, generating a random ID if they are empty
-func newClient(id []byte, clientKey keys.KeyMaterial, persistStatePath string) (Client, error) {
+func newClient(id []byte, clientKey keys.KeyMaterial, store io.WriteSeeker) (Client, error) {
 	if len(id) == 0 {
 		return nil, errors.New("client id must not be empty")
 	}
@@ -264,8 +264,9 @@ func newClient(id []byte, clientKey keys.KeyMaterial, persistStatePath string) (
 	c := &client{
 		Key:            clientKey,
 		TopicKeys:      make(map[string]keys.TopicKey),
-		FilePath:       persistStatePath,
 		ReceivingTopic: TopicForID(id),
+
+		store: store,
 	}
 
 	c.ID = make([]byte, len(id))
@@ -277,47 +278,33 @@ func newClient(id []byte, clientKey keys.KeyMaterial, persistStatePath string) (
 }
 
 // LoadClient loads a client state from the file system
-func LoadClient(persistStatePath string) (Client, error) {
+func LoadClient(store io.ReadWriteSeeker) (Client, error) {
 	c := &client{}
-	err := readJSON(persistStatePath, c)
+
+	decoder := json.NewDecoder(store)
+	err := decoder.Decode(c)
 	if err != nil {
 		return nil, err
 	}
+
+	store.Seek(0, io.SeekStart)
+
+	c.store = store
 
 	return c, nil
 }
 
 func (c *client) save() error {
-	err := writeJSON(c.FilePath, c)
+	encoder := json.NewEncoder(c.store)
+	err := encoder.Encode(c)
 	if err != nil {
 		log.Printf("failed to save client: %v", err)
 		return err
 	}
+
+	c.store.Seek(0, io.SeekStart)
+
 	return nil
-}
-
-func writeJSON(filePath string, object interface{}) error {
-	file, err := os.Create(filePath)
-	if err != nil {
-		return fmt.Errorf("failed to create file at %s: %v", filePath, err)
-	}
-	defer file.Close()
-
-	encoder := json.NewEncoder(file)
-	err = encoder.Encode(object)
-
-	return err
-}
-
-func readJSON(filePath string, object interface{}) error {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	decoder := json.NewDecoder(file)
-	return decoder.Decode(object)
 }
 
 func (c *client) UnmarshalJSON(data []byte) error {
@@ -338,12 +325,6 @@ func (c *client) UnmarshalJSON(data []byte) error {
 	if rawReceivingTopic, ok := m["ReceivingTopic"]; ok {
 		if err := json.Unmarshal(rawReceivingTopic, &c.ReceivingTopic); err != nil {
 			return fmt.Errorf("failed to unmarshal client receiving topic: %v", err)
-		}
-	}
-
-	if rawFilePath, ok := m["FilePath"]; ok {
-		if err := json.Unmarshal(rawFilePath, &c.FilePath); err != nil {
-			return fmt.Errorf("failed to unmarshal client filepath: %v", err)
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -41,7 +41,10 @@ func TestNewClientSymKey(t *testing.T) {
 	rand.Read(id)
 	rand.Read(k)
 
-	c, err := NewClient(&SymIDAndKey{ID: id, Key: k}, NewMemoryStore(nil))
+	c, err := NewClient(&SymIDAndKey{
+		ID:  id,
+		Key: k,
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +80,9 @@ func TestNewClientSymKey(t *testing.T) {
 }
 
 func TestProtectUnprotectMessageSymKey(t *testing.T) {
-	client, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, NewMemoryStore(nil))
+	client, err := NewClient(&SymIDAndKey{
+		Key: e4crypto.RandomKey(),
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -98,7 +103,7 @@ func TestProtectUnprotectMessagePubKey(t *testing.T) {
 		ID:       clientID,
 		Key:      privateKey,
 		C2PubKey: generateCurve25519PubKey(t),
-	}, NewMemoryStore(nil))
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -200,7 +205,10 @@ func TestKeyTransition(t *testing.T) {
 	clientKey := e4crypto.RandomKey()
 	topic := "topic"
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, NewMemoryStore(nil))
+	c, err := NewClient(&SymIDAndKey{
+		ID:  clientID,
+		Key: clientKey,
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -257,8 +265,10 @@ func TestKeyTransition(t *testing.T) {
 }
 
 func TestClientWriteRead(t *testing.T) {
-	store := NewMemoryStore(nil)
-	gc, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, store)
+	store := NewInMemoryStore(nil)
+	gc, err := NewClient(&SymIDAndKey{
+		Key: e4crypto.RandomKey(),
+	}, store)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -321,7 +331,11 @@ func TestProtectUnprotectCommandsPubKey(t *testing.T) {
 	}
 
 	clientID := e4crypto.RandomID()
-	gc, err := NewClient(&PubIDAndKey{ID: clientID, Key: clientEdSk, C2PubKey: c2PublicCurveKey}, NewMemoryStore(nil))
+	gc, err := NewClient(&PubIDAndKey{
+		ID:       clientID,
+		Key:      clientEdSk,
+		C2PubKey: c2PublicCurveKey,
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -354,7 +368,7 @@ func TestClientPubKeys(t *testing.T) {
 			t.Fatalf("failed to get pubkey from config: %v", err)
 		}
 
-		store := NewMemoryStore(nil)
+		store := NewInMemoryStore(nil)
 		c, err := NewClient(config, store)
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
@@ -449,7 +463,7 @@ func TestClientPubKeys(t *testing.T) {
 			t.Fatalf("failed to get pubkey from config: %v", err)
 		}
 
-		c, err := NewClient(config, NewMemoryStore(nil))
+		c, err := NewClient(config, NewInMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -473,7 +487,10 @@ func TestClientPubKeys(t *testing.T) {
 	})
 
 	t.Run("symClient must return unsupported operations on pubKey methods", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "testClient", Password: "passwordTestRandom"}, NewMemoryStore(nil))
+		symClient, err := NewClient(&SymNameAndPassword{
+			Name:     "testClient",
+			Password: "passwordTestRandom",
+		}, NewInMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create symClient: %v", err)
 		}
@@ -498,7 +515,10 @@ func TestClientPubKeys(t *testing.T) {
 
 func TestClientTopics(t *testing.T) {
 	t.Run("topic key operations properly update client state", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, NewMemoryStore(nil))
+		symClient, err := NewClient(&SymNameAndPassword{
+			Name:     "clientID",
+			Password: "passwordTestRandom",
+		}, NewInMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -550,7 +570,10 @@ func TestClientTopics(t *testing.T) {
 	})
 
 	t.Run("topic key operations returns errors when invoked with bad topic hashes", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, NewMemoryStore(nil))
+		symClient, err := NewClient(&SymNameAndPassword{
+			Name:     "clientID",
+			Password: "passwordTestRandom",
+		}, NewInMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -572,7 +595,10 @@ func TestClientSetIDKey(t *testing.T) {
 	validKey := e4crypto.RandomKey()
 	invalidKey := make([]byte, e4crypto.KeyLen)
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: validKey}, NewMemoryStore(nil))
+	c, err := NewClient(&SymIDAndKey{
+		ID:  clientID,
+		Key: validKey,
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -588,7 +614,10 @@ func TestCommandsSymClient(t *testing.T) {
 	clientKey := e4crypto.RandomKey()
 	topic := "topic1"
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, NewMemoryStore(nil))
+	c, err := NewClient(&SymIDAndKey{
+		ID:  clientID,
+		Key: clientKey,
+	}, NewInMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -42,7 +41,7 @@ func TestNewClientSymKey(t *testing.T) {
 	rand.Read(id)
 	rand.Read(k)
 
-	c, err := NewClient(&SymIDAndKey{ID: id, Key: k}, NewMemoryStore())
+	c, err := NewClient(&SymIDAndKey{ID: id, Key: k}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +77,7 @@ func TestNewClientSymKey(t *testing.T) {
 }
 
 func TestProtectUnprotectMessageSymKey(t *testing.T) {
-	client, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, NewMemoryStore())
+	client, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -99,7 +98,7 @@ func TestProtectUnprotectMessagePubKey(t *testing.T) {
 		ID:       clientID,
 		Key:      privateKey,
 		C2PubKey: generateCurve25519PubKey(t),
-	}, NewMemoryStore())
+	}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -201,7 +200,7 @@ func TestKeyTransition(t *testing.T) {
 	clientKey := e4crypto.RandomKey()
 	topic := "topic"
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, NewMemoryStore())
+	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -258,7 +257,7 @@ func TestKeyTransition(t *testing.T) {
 }
 
 func TestClientWriteRead(t *testing.T) {
-	store := NewMemoryStore()
+	store := NewMemoryStore(nil)
 	gc, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, store)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
@@ -289,14 +288,10 @@ func TestClientWriteRead(t *testing.T) {
 		t.Fatalf("ResetTopics failed: %s", err)
 	}
 
-	fmt.Printf("%s\n\n", store)
-
-	fmt.Printf("%#v\n\n", gc)
 	gcc, err := LoadClient(store)
 	if err != nil {
 		t.Fatalf("Failed to load client: %s", err)
 	}
-	fmt.Printf("%#v\n", gcc)
 	if !reflect.DeepEqual(gcc, gc) {
 		t.Fatalf("Invalid loaded client, got %#v, wanted %#v", gcc, gc)
 	}
@@ -326,7 +321,7 @@ func TestProtectUnprotectCommandsPubKey(t *testing.T) {
 	}
 
 	clientID := e4crypto.RandomID()
-	gc, err := NewClient(&PubIDAndKey{ID: clientID, Key: clientEdSk, C2PubKey: c2PublicCurveKey}, NewMemoryStore())
+	gc, err := NewClient(&PubIDAndKey{ID: clientID, Key: clientEdSk, C2PubKey: c2PublicCurveKey}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -359,7 +354,7 @@ func TestClientPubKeys(t *testing.T) {
 			t.Fatalf("failed to get pubkey from config: %v", err)
 		}
 
-		store := NewMemoryStore()
+		store := NewMemoryStore(nil)
 		c, err := NewClient(config, store)
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
@@ -454,7 +449,7 @@ func TestClientPubKeys(t *testing.T) {
 			t.Fatalf("failed to get pubkey from config: %v", err)
 		}
 
-		c, err := NewClient(config, NewMemoryStore())
+		c, err := NewClient(config, NewMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -478,7 +473,7 @@ func TestClientPubKeys(t *testing.T) {
 	})
 
 	t.Run("symClient must return unsupported operations on pubKey methods", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "testClient", Password: "passwordTestRandom"}, NewMemoryStore())
+		symClient, err := NewClient(&SymNameAndPassword{Name: "testClient", Password: "passwordTestRandom"}, NewMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create symClient: %v", err)
 		}
@@ -503,7 +498,7 @@ func TestClientPubKeys(t *testing.T) {
 
 func TestClientTopics(t *testing.T) {
 	t.Run("topic key operations properly update client state", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, NewMemoryStore())
+		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, NewMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -555,7 +550,7 @@ func TestClientTopics(t *testing.T) {
 	})
 
 	t.Run("topic key operations returns errors when invoked with bad topic hashes", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, NewMemoryStore())
+		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, NewMemoryStore(nil))
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -577,7 +572,7 @@ func TestClientSetIDKey(t *testing.T) {
 	validKey := e4crypto.RandomKey()
 	invalidKey := make([]byte, e4crypto.KeyLen)
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: validKey}, NewMemoryStore())
+	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: validKey}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -593,7 +588,7 @@ func TestCommandsSymClient(t *testing.T) {
 	clientKey := e4crypto.RandomKey()
 	topic := "topic1"
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, NewMemoryStore())
+	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, NewMemoryStore(nil))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/cmd/e4client/e4client.go
+++ b/cmd/e4client/e4client.go
@@ -234,30 +234,32 @@ func loadOrCreateClient(name, password string) (e4.Client, error) {
 	var e4Client e4.Client
 
 	savedClientPath := fmt.Sprintf("./%s.json", name)
-	saveFile, err := os.OpenFile(savedClientPath, os.O_RDWR, 0600)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			fmt.Printf("Failed to load client from file %s: %v\n", savedClientPath, err)
-			os.Exit(1)
-		}
-
-		saveFile, err := os.OpenFile(savedClientPath, os.O_CREATE|os.O_RDWR, 0600)
-		if err != nil {
-			fmt.Printf("Failed to create client save file %s: %v\n", savedClientPath, err)
-			os.Exit(1)
-		}
-
-		e4Client, err = e4.NewClient(&e4.SymNameAndPassword{Name: name, Password: password}, saveFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create E4 client: %v", err)
-		}
-	} else {
-		e4Client, err = e4.LoadClient(saveFile)
+	dstFile, err := os.OpenFile(savedClientPath, os.O_RDWR, 0600)
+	switch {
+	case err == nil:
+		e4Client, err = e4.LoadClient(dstFile)
 		if err != nil {
 			fmt.Printf("Failed to load client from file %s: %v\n", savedClientPath, err)
 			os.Exit(1)
 		}
 		fmt.Printf("Loaded client from %s\n", savedClientPath)
+
+	default:
+		if !os.IsNotExist(err) {
+			fmt.Printf("Failed to load client from file %s: %v\n", savedClientPath, err)
+			os.Exit(1)
+		}
+
+		dstFile, err := os.OpenFile(savedClientPath, os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			fmt.Printf("Failed to create client save file %s: %v\n", savedClientPath, err)
+			os.Exit(1)
+		}
+
+		e4Client, err = e4.NewClient(&e4.SymNameAndPassword{Name: name, Password: password}, dstFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create E4 client: %v", err)
+		}
 	}
 
 	return e4Client, nil

--- a/example_test.go
+++ b/example_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func ExampleNewClient_symIDAndKey() {
-	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, "./symClient.json")
+	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, e4.NewMemoryStore())
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ func ExampleNewClient_symIDAndKey() {
 }
 
 func ExampleNewClient_symNameAndPassword() {
-	client, err := e4.NewClient(&e4.SymNameAndPassword{Name: "clientName", Password: "verySecretPassword"}, "./symClient.json")
+	client, err := e4.NewClient(&e4.SymNameAndPassword{Name: "clientName", Password: "verySecretPassword"}, e4.NewMemoryStore())
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ func ExampleNewClient_pubIDAndKey() {
 		ID:       []byte("clientID"),
 		Key:      privateKey,
 		C2PubKey: c2PubKey,
-	}, "./pubClient.json")
+	}, e4.NewMemoryStore())
 
 	if err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func ExampleNewClient_pubNameAndPassword() {
 		C2PubKey: c2PubKey,
 	}
 
-	client, err := e4.NewClient(config, "./pubClient.json")
+	client, err := e4.NewClient(config, e4.NewMemoryStore())
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func ExampleNewClient_symIDAndKey() {
-	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, e4.NewMemoryStore())
+	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, e4.NewMemoryStore(nil))
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ func ExampleNewClient_symIDAndKey() {
 }
 
 func ExampleNewClient_symNameAndPassword() {
-	client, err := e4.NewClient(&e4.SymNameAndPassword{Name: "clientName", Password: "verySecretPassword"}, e4.NewMemoryStore())
+	client, err := e4.NewClient(&e4.SymNameAndPassword{Name: "clientName", Password: "verySecretPassword"}, e4.NewMemoryStore(nil))
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ func ExampleNewClient_pubIDAndKey() {
 		ID:       []byte("clientID"),
 		Key:      privateKey,
 		C2PubKey: c2PubKey,
-	}, e4.NewMemoryStore())
+	}, e4.NewMemoryStore(nil))
 
 	if err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func ExampleNewClient_pubNameAndPassword() {
 		C2PubKey: c2PubKey,
 	}
 
-	client, err := e4.NewClient(config, e4.NewMemoryStore())
+	client, err := e4.NewClient(config, e4.NewMemoryStore(nil))
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,10 @@ import (
 )
 
 func ExampleNewClient_symIDAndKey() {
-	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, e4.NewMemoryStore(nil))
+	client, err := e4.NewClient(&e4.SymIDAndKey{
+		ID:  []byte("clientID"),
+		Key: e4crypto.RandomKey(),
+	}, e4.NewInMemoryStore(nil))
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +36,6 @@ func ExampleNewClient_symIDAndKey() {
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Printf("Protected message: %v", protectedMessage)
 }
 
@@ -44,7 +46,10 @@ func ExampleNewClient_fileStorage() {
 	}
 	defer f.Close()
 
-	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, f)
+	client, err := e4.NewClient(&e4.SymIDAndKey{
+		ID:  []byte("clientID"),
+		Key: e4crypto.RandomKey(),
+	}, f)
 	if err != nil {
 		panic(err)
 	}
@@ -53,12 +58,14 @@ func ExampleNewClient_fileStorage() {
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Printf("Protected message: %v", protectedMessage)
 }
 
 func ExampleNewClient_symNameAndPassword() {
-	client, err := e4.NewClient(&e4.SymNameAndPassword{Name: "clientName", Password: "verySecretPassword"}, e4.NewMemoryStore(nil))
+	client, err := e4.NewClient(&e4.SymNameAndPassword{
+		Name:     "clientName",
+		Password: "verySecretPassword",
+	}, e4.NewInMemoryStore(nil))
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +74,6 @@ func ExampleNewClient_symNameAndPassword() {
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Printf("Protected message: %v", protectedMessage)
 }
 
@@ -86,7 +92,7 @@ func ExampleNewClient_pubIDAndKey() {
 		ID:       []byte("clientID"),
 		Key:      privateKey,
 		C2PubKey: c2PubKey,
-	}, e4.NewMemoryStore(nil))
+	}, e4.NewInMemoryStore(nil))
 
 	if err != nil {
 		panic(err)
@@ -96,7 +102,6 @@ func ExampleNewClient_pubIDAndKey() {
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Printf("Protected message: %v", protectedMessage)
 }
 
@@ -105,13 +110,13 @@ func ExampleNewClient_pubNameAndPassword() {
 	if err != nil {
 		panic(err)
 	}
+
 	config := &e4.PubNameAndPassword{
 		Name:     "clientName",
 		Password: "verySecretPassword",
 		C2PubKey: c2PubKey,
 	}
-
-	client, err := e4.NewClient(config, e4.NewMemoryStore(nil))
+	client, err := e4.NewClient(config, e4.NewInMemoryStore(nil))
 	if err != nil {
 		panic(err)
 	}
@@ -127,6 +132,5 @@ func ExampleNewClient_pubNameAndPassword() {
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Printf("Protected message: %v", protectedMessage)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -16,6 +16,7 @@ package e4_test
 
 import (
 	"fmt"
+	"os"
 
 	e4 "github.com/teserakt-io/e4go"
 	e4crypto "github.com/teserakt-io/e4go/crypto"
@@ -24,6 +25,26 @@ import (
 
 func ExampleNewClient_symIDAndKey() {
 	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, e4.NewMemoryStore(nil))
+	if err != nil {
+		panic(err)
+	}
+
+	protectedMessage, err := client.ProtectMessage([]byte("very secret message"), "topic/name")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Protected message: %v", protectedMessage)
+}
+
+func ExampleNewClient_fileStorage() {
+	f, err := os.OpenFile("/storage/clientID.json", os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	client, err := e4.NewClient(&e4.SymIDAndKey{ID: []byte("clientID"), Key: e4crypto.RandomKey()}, f)
 	if err != nil {
 		panic(err)
 	}

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Teserakt AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e4
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+type memoryStore struct {
+	buf   *bytes.Buffer
+	index int64
+}
+
+var _ io.ReadWriteSeeker = (*memoryStore)(nil)
+
+// NewMemoryStore creates a new io.ReadWriteSeeker storing data in memory
+func NewMemoryStore() io.ReadWriteSeeker {
+	return &memoryStore{
+		buf: bytes.NewBuffer(nil),
+	}
+}
+
+func (s *memoryStore) Write(p []byte) (n int, err error) {
+	if s.index < 0 {
+		return 0, io.EOF
+	}
+
+	idx := int(s.index)
+	bufLen := s.buf.Len()
+	if idx != bufLen && idx <= bufLen {
+		bufSlice := s.buf.Bytes()[:s.index]
+		s.buf = bytes.NewBuffer(bufSlice)
+	}
+
+	n, err = s.buf.Write(p)
+	s.index += int64(n)
+
+	return n, err
+}
+
+func (s *memoryStore) Read(b []byte) (n int, err error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	if s.index >= int64(s.buf.Len()) {
+		return 0, io.EOF
+	}
+
+	bufSlice := s.buf.Bytes()[s.index:]
+	n, err = bytes.NewBuffer(bufSlice).Read(b)
+	s.index += int64(n)
+
+	return n, err
+}
+
+func (s *memoryStore) Seek(offset int64, whence int) (idx int64, err error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = int64(s.index) + offset
+	case io.SeekEnd:
+		abs = int64(s.buf.Len()) + offset
+	default:
+		return 0, errors.New("invalid whence")
+	}
+	if abs < 0 {
+		return 0, errors.New("negative position")
+	}
+
+	s.index = abs
+	return abs, nil
+}

--- a/storage.go
+++ b/storage.go
@@ -20,13 +20,11 @@ import (
 	"io"
 )
 
-// Store defines an interface for E4 storage implementation
-// it is compatible with io.ReadWriteSeeker but redefined to allow this type to be exported
-// from bindings generation
-type Store interface {
-	Write(p []byte) (n int, err error)
-	Read(b []byte) (n int, err error)
-	Seek(offset int64, whence int) (idx int64, err error)
+// ReadWriteSeeker is a redefinition of io.ReadWriteSeeker
+// to ensure that gomobile bindings still get generated without
+// incompatible type removals
+type ReadWriteSeeker interface {
+	io.ReadWriteSeeker
 }
 
 type memoryStore struct {
@@ -34,10 +32,10 @@ type memoryStore struct {
 	index int64
 }
 
-var _ Store = (*memoryStore)(nil)
+var _ ReadWriteSeeker = (*memoryStore)(nil)
 
-// NewMemoryStore creates a new Store in memory
-func NewMemoryStore(buf []byte) Store {
+// NewMemoryStore creates a new ReadWriteSeeker in memory
+func NewMemoryStore(buf []byte) ReadWriteSeeker {
 	return &memoryStore{
 		buf: bytes.NewBuffer(buf),
 	}

--- a/storage.go
+++ b/storage.go
@@ -27,21 +27,21 @@ type ReadWriteSeeker interface {
 	io.ReadWriteSeeker
 }
 
-type memoryStore struct {
+type inMemoryStore struct {
 	buf   *bytes.Buffer
 	index int64
 }
 
-var _ ReadWriteSeeker = (*memoryStore)(nil)
+var _ ReadWriteSeeker = (*inMemoryStore)(nil)
 
-// NewMemoryStore creates a new ReadWriteSeeker in memory
-func NewMemoryStore(buf []byte) ReadWriteSeeker {
-	return &memoryStore{
+// NewInMemoryStore creates a new ReadWriteSeeker in memory
+func NewInMemoryStore(buf []byte) ReadWriteSeeker {
+	return &inMemoryStore{
 		buf: bytes.NewBuffer(buf),
 	}
 }
 
-func (s *memoryStore) Write(p []byte) (n int, err error) {
+func (s *inMemoryStore) Write(p []byte) (n int, err error) {
 	if s.index < 0 {
 		return 0, io.EOF
 	}
@@ -59,7 +59,7 @@ func (s *memoryStore) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-func (s *memoryStore) Read(b []byte) (n int, err error) {
+func (s *inMemoryStore) Read(b []byte) (n int, err error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
@@ -74,7 +74,7 @@ func (s *memoryStore) Read(b []byte) (n int, err error) {
 	return n, err
 }
 
-func (s *memoryStore) Seek(offset int64, whence int) (idx int64, err error) {
+func (s *inMemoryStore) Seek(offset int64, whence int) (idx int64, err error) {
 	var abs int64
 	switch whence {
 	case io.SeekStart:

--- a/storage.go
+++ b/storage.go
@@ -45,10 +45,8 @@ func NewInMemoryStore(buf []byte) ReadWriteSeeker {
 }
 
 func (s *inMemoryStore) Write(p []byte) (n int, err error) {
-	bufLen := len(s.buf)
-	if s.index < bufLen {
-		bufSlice := s.buf[:s.index]
-		s.buf = bufSlice
+	if s.index < len(s.buf) {
+		s.buf = s.buf[:s.index]
 	}
 
 	s.buf = append(s.buf, p...)

--- a/storage.go
+++ b/storage.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Teserakt AG
+// Copyright 2020 Teserakt AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,17 +20,26 @@ import (
 	"io"
 )
 
+// Store defines an interface for E4 storage implementation
+// it is compatible with io.ReadWriteSeeker but redefined to allow this type to be exported
+// from bindings generation
+type Store interface {
+	Write(p []byte) (n int, err error)
+	Read(b []byte) (n int, err error)
+	Seek(offset int64, whence int) (idx int64, err error)
+}
+
 type memoryStore struct {
 	buf   *bytes.Buffer
 	index int64
 }
 
-var _ io.ReadWriteSeeker = (*memoryStore)(nil)
+var _ Store = (*memoryStore)(nil)
 
-// NewMemoryStore creates a new io.ReadWriteSeeker storing data in memory
-func NewMemoryStore() io.ReadWriteSeeker {
+// NewMemoryStore creates a new Store in memory
+func NewMemoryStore(buf []byte) Store {
 	return &memoryStore{
-		buf: bytes.NewBuffer(nil),
+		buf: bytes.NewBuffer(buf),
 	}
 }
 

--- a/storage.go
+++ b/storage.go
@@ -45,9 +45,8 @@ func NewInMemoryStore(buf []byte) ReadWriteSeeker {
 }
 
 func (s *inMemoryStore) Write(p []byte) (n int, err error) {
-	idx := int(s.index)
 	bufLen := len(s.buf)
-	if idx != bufLen && idx <= bufLen {
+	if s.index < bufLen {
 		bufSlice := s.buf[:s.index]
 		s.buf = bufSlice
 	}
@@ -56,7 +55,7 @@ func (s *inMemoryStore) Write(p []byte) (n int, err error) {
 	n = len(p)
 	s.index += n
 
-	return n, err
+	return n, nil
 }
 
 func (s *inMemoryStore) Read(b []byte) (n int, err error) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Teserakt AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e4
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestMemoryStore(t *testing.T) {
+	store := NewMemoryStore(nil)
+
+	expected := []byte("abcde")
+
+	n, err := store.Write(expected)
+	if err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if n != len(expected) {
+		t.Fatalf("expected n to be %d, got %d", len(expected), n)
+	}
+
+	readBuf := make([]byte, len(expected))
+	_, err = store.Read(readBuf)
+	if err != io.EOF {
+		t.Fatalf("expected read EOF, got %v", err)
+	}
+
+	idx, err := store.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatalf("unexpected seek error: %v", err)
+	}
+	if idx != 0 {
+		t.Fatalf("unexpected idx, want %d, got %d", 0, idx)
+	}
+
+	n, err = store.Read(readBuf)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if n != len(expected) {
+		t.Fatalf("expected n to be %d, got %d", len(expected), n)
+	}
+	if !bytes.Equal(readBuf, expected) {
+		t.Fatalf("expected readBuf to be %v, got %v", expected, readBuf)
+	}
+
+	idx, err = store.Seek(-2, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("unexpected seek error: %v", err)
+	}
+	if idx != int64(len(expected)-2) {
+		t.Fatalf("unexpected idx, want %d, got %d", len(expected)-2, idx)
+	}
+
+	readBuf = make([]byte, len(expected)-3)
+	n, err = store.Read(readBuf)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if n != len(expected)-3 {
+		t.Fatalf("expected n to be %d, got %d", len(expected)-3, n)
+	}
+	if !bytes.Equal(readBuf, expected[3:]) {
+		t.Fatalf("expected readBuf to be %v, got %v", expected[3:], readBuf)
+	}
+
+	idx, err = store.Seek(-1, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("unexpected seek error: %v", err)
+	}
+	if idx != int64(len(expected)-1) {
+		t.Fatalf("unexpected idx, want %d, got %d", len(expected)-1, idx)
+	}
+
+	readBuf = make([]byte, 1)
+	n, err = store.Read(readBuf)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected n to be %d, got %d", 1, n)
+	}
+	if !bytes.Equal(readBuf, expected[len(expected)-1:]) {
+		t.Fatalf("expected readBuf to be %v, got %v", expected[len(expected)-1:], readBuf)
+	}
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 )
 
-func TestMemoryStore(t *testing.T) {
-	store := NewMemoryStore(nil)
+func TestInMemoryStore(t *testing.T) {
+	store := NewInMemoryStore(nil)
 
 	expected := []byte("abcde")
 


### PR DESCRIPTION
Removed explicit dependency on file system by introducing an `e4.Store` interface, which duplicate the standard `io.ReadWriteSeeker` in order to allow export for android bindings. 

To store on filesystem, users now need to provide an `os.File` to the `e4.NewClient()`.
Included an example in-memory store.

Fix #31 
