### PR TITLE
Precompute sharedkey

### DIFF
--- a/client.go
+++ b/client.go
@@ -104,7 +104,7 @@ type Client interface {
 	// resetTopics will remove all previously set topics from the client.
 	resetTopics() error
 	// setC2Key instructs the device to replace the current C2 public key with the newly transmitted one.
-	setC2Key(c2PUbKey e4crypto.Curve25519PublicKey) error
+	setC2Key(newC2PubKey e4crypto.Curve25519PublicKey) error
 }
 
 // client implements Client interface
@@ -592,17 +592,17 @@ func (c *client) setIDKey(key []byte) error {
 	return c.save()
 }
 
-func (c *client) setC2Key(c2PubKey e4crypto.Curve25519PublicKey) error {
+func (c *client) setC2Key(newC2PubKey e4crypto.Curve25519PublicKey) error {
 	pkStore, ok := c.Key.(keys.PubKeyStore)
 	if !ok {
 		return ErrUnsupportedOperation
 	}
 
-	if err := e4crypto.ValidateCurve25519PubKey(c2PubKey); err != nil {
+	if err := e4crypto.ValidateCurve25519PubKey(newC2PubKey); err != nil {
 		return fmt.Errorf("invalid c2 public key: %v", err)
 	}
 
-	if err := pkStore.SetC2PubKey(c2PubKey); err != nil {
+	if err := pkStore.SetC2PubKey(newC2PubKey); err != nil {
 		return err
 	}
 

--- a/client.go
+++ b/client.go
@@ -103,6 +103,8 @@ type Client interface {
 	removeTopic(topicHash []byte) error
 	// resetTopics will remove all previously set topics from the client.
 	resetTopics() error
+	// setC2Key instructs the device to replace the current C2 public key with the newly transmitted one.
+	setC2Key(c2PUbKey e4crypto.Curve25519PublicKey) error
 }
 
 // client implements Client interface
@@ -584,6 +586,23 @@ func (c *client) setIDKey(key []byte) error {
 	defer c.lock.Unlock()
 
 	if err := c.Key.SetKey(key); err != nil {
+		return err
+	}
+
+	return c.save()
+}
+
+func (c *client) setC2Key(c2PubKey e4crypto.Curve25519PublicKey) error {
+	pkStore, ok := c.Key.(keys.PubKeyStore)
+	if !ok {
+		return ErrUnsupportedOperation
+	}
+
+	if err := e4crypto.ValidateCurve25519PubKey(c2PubKey); err != nil {
+		return fmt.Errorf("invalid c2 public key: %v", err)
+	}
+
+	if err := pkStore.SetC2PubKey(c2PubKey); err != nil {
 		return err
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -42,7 +42,10 @@ func TestNewClientSymKey(t *testing.T) {
 
 	path := "./test/data/clienttestnew"
 
-	c, err := NewClient(&SymIDAndKey{ID: id, Key: k}, path)
+	c, err := NewClient(&SymIDAndKey{
+		ID:  id,
+		Key: k,
+	}, path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +85,10 @@ func TestNewClientSymKey(t *testing.T) {
 }
 
 func TestProtectUnprotectMessageSymKey(t *testing.T) {
-	client, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, "./test/data/clienttestprotectSymKey")
+	client, err := NewClient(&SymIDAndKey{
+		Key: e4crypto.RandomKey(),
+	}, "./test/data/clienttestprotectSymKey")
+
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -205,7 +211,10 @@ func TestKeyTransition(t *testing.T) {
 	clientKey := e4crypto.RandomKey()
 	topic := "topic"
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, "./test/data/testkeytransition")
+	c, err := NewClient(&SymIDAndKey{
+		ID:  clientID,
+		Key: clientKey,
+	}, "./test/data/testkeytransition")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -264,7 +273,9 @@ func TestKeyTransition(t *testing.T) {
 func TestClientWriteRead(t *testing.T) {
 	filePath := "./test/data/clienttestwriteread"
 
-	gc, err := NewClient(&SymIDAndKey{Key: e4crypto.RandomKey()}, filePath)
+	gc, err := NewClient(&SymIDAndKey{
+		Key: e4crypto.RandomKey(),
+	}, filePath)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -328,7 +339,11 @@ func TestProtectUnprotectCommandsPubKey(t *testing.T) {
 	}
 
 	clientID := e4crypto.RandomID()
-	gc, err := NewClient(&PubIDAndKey{ID: clientID, Key: clientEdSk, C2PubKey: c2PublicCurveKey}, "./test/data/clienttestcommand")
+	gc, err := NewClient(&PubIDAndKey{
+		ID:       clientID,
+		Key:      clientEdSk,
+		C2PubKey: c2PublicCurveKey,
+	}, "./test/data/clienttestcommand")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -483,7 +498,10 @@ func TestClientPubKeys(t *testing.T) {
 	})
 
 	t.Run("symClient must return unsupported operations on pubKey methods", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "testClient", Password: "passwordTestRandom"}, "./symclienttestpubkeys")
+		symClient, err := NewClient(&SymNameAndPassword{
+			Name:     "testClient",
+			Password: "passwordTestRandom",
+		}, "./symclienttestpubkeys")
 		if err != nil {
 			t.Fatalf("Failed to create symClient: %v", err)
 		}
@@ -508,7 +526,10 @@ func TestClientPubKeys(t *testing.T) {
 
 func TestClientTopics(t *testing.T) {
 	t.Run("topic key operations properly update client state", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, "./test/data/testclienttopics")
+		symClient, err := NewClient(&SymNameAndPassword{
+			Name:     "clientID",
+			Password: "passwordTestRandom",
+		}, "./test/data/testclienttopics")
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -560,7 +581,10 @@ func TestClientTopics(t *testing.T) {
 	})
 
 	t.Run("topic key operations returns errors when invoked with bad topic hashes", func(t *testing.T) {
-		symClient, err := NewClient(&SymNameAndPassword{Name: "clientID", Password: "passwordTestRandom"}, "./test/data/testclienttopics")
+		symClient, err := NewClient(&SymNameAndPassword{
+			Name:     "clientID",
+			Password: "passwordTestRandom",
+		}, "./test/data/testclienttopics")
 		if err != nil {
 			t.Fatalf("Failed to create client: %v", err)
 		}
@@ -582,7 +606,10 @@ func TestClientSetIDKey(t *testing.T) {
 	validKey := e4crypto.RandomKey()
 	invalidKey := make([]byte, e4crypto.KeyLen)
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: validKey}, "./test/data/testSetIdKeyClient")
+	c, err := NewClient(&SymIDAndKey{
+		ID:  clientID,
+		Key: validKey,
+	}, "./test/data/testSetIdKeyClient")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -599,7 +626,10 @@ func TestClientSetC2Key(t *testing.T) {
 		t.Fatalf("failed to generate public curve25519 key: %v", err)
 	}
 
-	c, err := NewClient(&SymIDAndKey{ID: e4crypto.HashIDAlias("client1"), Key: e4crypto.RandomKey()}, "./test/data/testSetC2KeyClient")
+	c, err := NewClient(&SymIDAndKey{
+		ID:  e4crypto.HashIDAlias("client1"),
+		Key: e4crypto.RandomKey(),
+	}, "./test/data/testSetC2KeyClient")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -613,7 +643,11 @@ func TestClientSetC2Key(t *testing.T) {
 		t.Fatalf("Failed to generate ed25519 private key: %v", err)
 	}
 
-	c, err = NewClient(&PubIDAndKey{ID: e4crypto.HashIDAlias("client1"), Key: edSk, C2PubKey: c2PubKey}, "./test/data/testSetC2KeyClient")
+	c, err = NewClient(&PubIDAndKey{
+		ID:       e4crypto.HashIDAlias("client1"),
+		Key:      edSk,
+		C2PubKey: c2PubKey,
+	}, "./test/data/testSetC2KeyClient")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -636,7 +670,10 @@ func TestCommandsSymClient(t *testing.T) {
 	clientKey := e4crypto.RandomKey()
 	topic := "topic1"
 
-	c, err := NewClient(&SymIDAndKey{ID: clientID, Key: clientKey}, "./test/data/testcommandsclient")
+	c, err := NewClient(&SymIDAndKey{
+		ID:  clientID,
+		Key: clientKey,
+	}, "./test/data/testcommandsclient")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -593,6 +593,44 @@ func TestClientSetIDKey(t *testing.T) {
 
 }
 
+func TestClientSetC2Key(t *testing.T) {
+	c2PubKey, err := curve25519.X25519(e4crypto.RandomKey(), curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("failed to generate public curve25519 key: %v", err)
+	}
+
+	c, err := NewClient(&SymIDAndKey{ID: e4crypto.HashIDAlias("client1"), Key: e4crypto.RandomKey()}, "./test/data/testSetC2KeyClient")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	if err := c.setC2Key(c2PubKey); err != ErrUnsupportedOperation {
+		t.Fatalf("Got error %v, wanted %v", err, ErrUnsupportedOperation)
+	}
+
+	_, edSk, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("Failed to generate ed25519 private key: %v", err)
+	}
+
+	c, err = NewClient(&PubIDAndKey{ID: e4crypto.HashIDAlias("client1"), Key: edSk, C2PubKey: c2PubKey}, "./test/data/testSetC2KeyClient")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	newC2PubKey, err := curve25519.X25519(e4crypto.RandomKey(), curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("failed to generate public curve25519 key: %v", err)
+	}
+	if err := c.setC2Key(newC2PubKey[1:]); err == nil {
+		t.Fatalf("Got no error while setting an invald c2 public key")
+	}
+
+	if err := c.setC2Key(newC2PubKey); err != nil {
+		t.Fatalf("Failed to set c2 public key: %v", err)
+	}
+}
+
 func TestCommandsSymClient(t *testing.T) {
 	clientID := e4crypto.HashIDAlias("client1")
 	clientKey := e4crypto.RandomKey()

--- a/client_test.go
+++ b/client_test.go
@@ -826,7 +826,7 @@ func TestCommandsSymClient(t *testing.T) {
 		t.Fatalf("Failed to protect command: %v", err)
 	}
 	if _, err := c.Unprotect(badProtectedSetPubKeyCmd, receivingTopic); err == nil {
-		t.Fatal("Expected an error with a bad setIDKey Command length")
+		t.Fatal("Expected an error with a bad setPubKey Command length")
 	}
 
 	_, err = c.Unprotect(protectedSetPubKeyCmd, receivingTopic)
@@ -848,7 +848,7 @@ func TestCommandsSymClient(t *testing.T) {
 		t.Fatalf("Failed to protect command: %v", err)
 	}
 	if _, err := c.Unprotect(badProtectedRemovePubKeyCmd, receivingTopic); err == nil {
-		t.Fatal("Expected an error with a bad setIDKey Command length")
+		t.Fatal("Expected an error with a bad removePubKey Command length")
 	}
 
 	_, err = c.Unprotect(protectedRemovePubKeyCmd, receivingTopic)
@@ -869,10 +869,33 @@ func TestCommandsSymClient(t *testing.T) {
 		t.Fatalf("Failed to protect command: %v", err)
 	}
 	if _, err := c.Unprotect(badProtectedResetPubKeyCmd, receivingTopic); err == nil {
-		t.Fatal("Expected an error with a bad setIDKey Command length")
+		t.Fatal("Expected an error with a bad resetPubKey Command length")
 	}
 
 	_, err = c.Unprotect(protectedResetPubKeyCmd, receivingTopic)
+	if err != ErrUnsupportedOperation {
+		t.Fatalf("Invalid error when unprotecting command: got %v, wanted %v", err, ErrUnsupportedOperation)
+	}
+
+	setC2KeyCmd := []byte{SetC2Key}
+	badProtectedSetC2KeyCmd, err := e4crypto.ProtectSymKey(append(setC2KeyCmd, 0x01), newClientKey)
+	if err != nil {
+		t.Fatalf("Failed to protect command: %v", err)
+	}
+	if _, err := c.Unprotect(badProtectedSetC2KeyCmd, receivingTopic); err == nil {
+		t.Fatal("Expected an error with a bad setC2Key Command length")
+	}
+
+	pubkey, err := curve25519.X25519(e4crypto.RandomKey(), curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("failed to generate pubkey: %v", err)
+	}
+	protectedSetC2KeyCmd, err := e4crypto.ProtectSymKey(append(setC2KeyCmd, pubkey...), newClientKey)
+	if err != nil {
+		t.Fatalf("Failed to protect command: %v", err)
+	}
+
+	_, err = c.Unprotect(protectedSetC2KeyCmd, receivingTopic)
 	if err != ErrUnsupportedOperation {
 		t.Fatalf("Invalid error when unprotecting command: got %v, wanted %v", err, ErrUnsupportedOperation)
 	}

--- a/commands.go
+++ b/commands.go
@@ -46,6 +46,9 @@ const (
 	// SetPubKey allows to set a public key on the client.
 	// It takes a public key, followed by an ID as arguments.
 	SetPubKey
+	//  SetC2Key allows to replace the current C2 public key
+	// with the newly transmitted one.
+	SetC2Key
 
 	// UnknownCommand must stay the last element. It's used to
 	// know if a Command is out of range
@@ -104,6 +107,11 @@ func processCommand(client Client, payload []byte) error {
 			return errors.New("invalid SetPubKey length")
 		}
 		return client.setPubKey(blob[:ed25519.PublicKeySize], blob[ed25519.PublicKeySize:])
+	case SetC2Key:
+		if len(blob) != e4crypto.Curve25519PubKeyLen {
+			return errors.New("invalid SetC2Key length")
+		}
+		return client.setC2Key(blob[:e4crypto.Curve25519PubKeyLen])
 
 	default:
 		return ErrInvalidCommand
@@ -184,6 +192,17 @@ func CmdSetPubKey(pubKey e4crypto.Ed25519PublicKey, name string) ([]byte, error)
 
 	cmd := append([]byte{SetPubKey}, pubKey...)
 	cmd = append(cmd, e4crypto.HashIDAlias(name)...)
+
+	return cmd, nil
+}
+
+// CmdSetC2Key creates a command to replace the c2 public key by the given one.
+func CmdSetC2Key(c2PubKey e4crypto.Curve25519PublicKey) ([]byte, error) {
+	if err := e4crypto.ValidateCurve25519PubKey(c2PubKey); err != nil {
+		return nil, fmt.Errorf("invalid c2 public key: %v", err)
+	}
+
+	cmd := append([]byte{SetC2Key}, c2PubKey...)
 
 	return cmd, nil
 }

--- a/commands.go
+++ b/commands.go
@@ -46,8 +46,7 @@ const (
 	// SetPubKey allows to set a public key on the client.
 	// It takes a public key, followed by an ID as arguments.
 	SetPubKey
-	//  SetC2Key allows to replace the current C2 public key
-	// with the newly transmitted one.
+	// SetC2PubKey replaces the current C2 public key with the newly transmitted one.
 	SetC2Key
 
 	// UnknownCommand must stay the last element. It's used to

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c/go.mod h1:X
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d h1:9FCpayM9Egr1baVnV1SX0H87m+XB0B8S0hAMi99X/3U=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=

--- a/keys/json.go
+++ b/keys/json.go
@@ -79,10 +79,12 @@ func FromRawJSON(raw json.RawMessage) (KeyMaterial, error) {
 	// Recompute shared key after unmarshalling the keymaterial
 	// as this field is not exported
 	pubKey, ok := clientKey.(*pubKeyMaterial)
-	if ok {
-		if err := pubKey.updateSharedKey(); err != nil {
-			return nil, err
-		}
+	if !ok {
+		return clientKey, nil
+	}
+
+	if err := pubKey.updateSharedKey(); err != nil {
+		return nil, err
 	}
 
 	return clientKey, nil

--- a/keys/json.go
+++ b/keys/json.go
@@ -72,5 +72,18 @@ func FromRawJSON(raw json.RawMessage) (KeyMaterial, error) {
 		return nil, err
 	}
 
+	if err := clientKey.validate(); err != nil {
+		return nil, fmt.Errorf("invalid clientKey: %v", err)
+	}
+
+	// Recompute shared key after unmarshalling the keymaterial
+	// as this field is not exported
+	pubKey, ok := clientKey.(*pubKeyMaterial)
+	if ok {
+		if err := pubKey.updateSharedKey(); err != nil {
+			return nil, err
+		}
+	}
+
 	return clientKey, nil
 }

--- a/keys/json_test.go
+++ b/keys/json_test.go
@@ -217,7 +217,6 @@ func TestFromRawJSON(t *testing.T) {
 		}
 
 		for _, testData := range testDatas {
-
 			c2PubKeyStr, err := json.Marshal(testData.c2PubKey)
 			if err != nil {
 				t.Fatalf("Failed to encode c2PubKey to string: %v", err)

--- a/keys/json_test.go
+++ b/keys/json_test.go
@@ -16,7 +16,6 @@ package keys
 
 import (
 	"bytes"
-	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -24,6 +23,7 @@ import (
 	"testing"
 
 	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/ed25519"
 
 	e4crypto "github.com/teserakt-io/e4go/crypto"
 )

--- a/keys/json_test.go
+++ b/keys/json_test.go
@@ -16,41 +16,67 @@ package keys
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"golang.org/x/crypto/curve25519"
+
+	e4crypto "github.com/teserakt-io/e4go/crypto"
 )
+
+var pubKeyJSONTempate = `{
+	"keyType": %d,
+	"keyData":{
+		"PrivateKey":"%s",
+		"SignerID":"%s",
+		"C2PubKey":%s,
+		"PubKeys":{
+			"%s": "%s"
+		}
+	}
+}`
+
+var symKeyJSONTemplate = `{
+	"keyType": %d,
+	"keyData":{
+		"Key":"%s"
+	}
+}`
 
 func TestFromRawJSON(t *testing.T) {
 	t.Run("FromRawJSON properly decode json ed25519 keys", func(t *testing.T) {
-		privateKey := []byte("privateKey")
-		signerID := []byte("signerID")
-		c2PubKey := []byte{}
+		_, privateKey, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			t.Fatalf("Failed to generate private key: %v", err)
+		}
+
+		signerID := e4crypto.HashIDAlias("signerID")
+		c2PubKey, err := curve25519.X25519(e4crypto.RandomKey(), curve25519.Basepoint)
+		if err != nil {
+			t.Fatalf("Failed to generate c2 public key")
+		}
+
 		c2PubKeyStr, err := json.Marshal(c2PubKey)
 		if err != nil {
 			t.Fatalf("Failed to encode c2PubKey to string: %v", err)
 		}
 
-		pubKeyID := "pubKeyID1"
-		pubKeyKey := []byte("pubKeyKey1")
+		pubKeyID := e4crypto.HashIDAlias("pubKeyID1")
+		pubKeyKey, _, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			t.Fatalf("Failed to generate public key: %v", err)
+		}
 
-		jsonKey := []byte(fmt.Sprintf(`{
-				"keyType": %d,
-				"keyData":{
-					"PrivateKey":"%s",
-					"SignerID":"%s",
-					"C2PubKey":%s,
-					"PubKeys":{
-						"%s": "%s"
-					}
-				}
-			}`,
+		jsonKey := []byte(fmt.Sprintf(pubKeyJSONTempate,
 			pubKeyMaterialType,
 			base64.StdEncoding.EncodeToString(privateKey),
 			base64.StdEncoding.EncodeToString(signerID),
 			c2PubKeyStr,
-			pubKeyID,
+			hex.EncodeToString(pubKeyID),
 			base64.StdEncoding.EncodeToString(pubKeyKey),
 		))
 
@@ -80,7 +106,7 @@ func TestFromRawJSON(t *testing.T) {
 			t.Fatalf("Invalid pubKey count: got %d, wanted 1", len(typedKey.PubKeys))
 		}
 
-		pk, ok := typedKey.PubKeys[pubKeyID]
+		pk, ok := typedKey.PubKeys[hex.EncodeToString(pubKeyID)]
 		if !ok {
 			t.Fatalf("Expected pubkeys to hold a key for id %s", pubKeyID)
 		}
@@ -91,14 +117,9 @@ func TestFromRawJSON(t *testing.T) {
 	})
 
 	t.Run("FromRawJSON properly decode json symmetric keys", func(t *testing.T) {
-		privateKey := []byte("privateKey")
+		privateKey := e4crypto.RandomKey()
 
-		jsonKey := []byte(fmt.Sprintf(`{
-				"keyType": %d,
-				"keyData":{
-					"Key":"%s"
-				}
-			}`,
+		jsonKey := []byte(fmt.Sprintf(symKeyJSONTemplate,
 			symKeyMaterialType,
 			base64.StdEncoding.EncodeToString(privateKey),
 		))
@@ -134,6 +155,99 @@ func TestFromRawJSON(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Expected an error when unmarshalling json `%s`", invalidJSON)
 			}
+		}
+	})
+
+	t.Run("FromRawJSON properly returns error when loading invalid pubkey data", func(t *testing.T) {
+		validPrivateKey := e4crypto.RandomKey()
+		validID := e4crypto.HashIDAlias("random")
+		validCurvePubKey, err := curve25519.X25519(e4crypto.RandomKey(), curve25519.Basepoint)
+		if err != nil {
+			t.Fatalf("Failed to generate c2 pubkey: %v", err)
+		}
+		validEdPubKey, _, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			t.Fatalf("Failed to generate public key: %v", err)
+		}
+
+		type testData struct {
+			privateKey []byte
+			signerID   []byte
+			c2PubKey   []byte
+			pubKeyID   []byte
+			pubKeyKey  []byte
+		}
+
+		testDatas := []testData{
+			{
+				privateKey: validPrivateKey[1:],
+				signerID:   validID,
+				c2PubKey:   validCurvePubKey,
+				pubKeyID:   validID,
+				pubKeyKey:  validEdPubKey,
+			},
+			{
+				privateKey: validPrivateKey,
+				signerID:   validID[1:],
+				c2PubKey:   validCurvePubKey,
+				pubKeyID:   validID,
+				pubKeyKey:  validEdPubKey,
+			},
+			{
+				privateKey: validPrivateKey,
+				signerID:   validID,
+				c2PubKey:   validCurvePubKey[1:],
+				pubKeyID:   validID,
+				pubKeyKey:  validEdPubKey,
+			},
+			{
+				privateKey: validPrivateKey,
+				signerID:   validID,
+				c2PubKey:   validCurvePubKey,
+				pubKeyID:   validID[1:],
+				pubKeyKey:  validEdPubKey,
+			},
+			{
+				privateKey: validPrivateKey,
+				signerID:   validID,
+				c2PubKey:   validCurvePubKey,
+				pubKeyID:   validID,
+				pubKeyKey:  validEdPubKey[1:],
+			},
+		}
+
+		for _, testData := range testDatas {
+
+			c2PubKeyStr, err := json.Marshal(testData.c2PubKey)
+			if err != nil {
+				t.Fatalf("Failed to encode c2PubKey to string: %v", err)
+			}
+
+			jsonKey := []byte(fmt.Sprintf(pubKeyJSONTempate,
+				pubKeyMaterialType,
+				base64.StdEncoding.EncodeToString(testData.privateKey),
+				base64.StdEncoding.EncodeToString(testData.signerID),
+				c2PubKeyStr,
+				hex.EncodeToString(testData.pubKeyID),
+				base64.StdEncoding.EncodeToString(testData.pubKeyKey),
+			))
+
+			_, err = FromRawJSON(jsonKey)
+			if err == nil {
+				t.Fatalf("An error was expected while unmarshalling invalid pubkey data %#v", testData)
+			}
+		}
+	})
+
+	t.Run("FromRawJSON properly returns error when loading invalid symkey data", func(t *testing.T) {
+		jsonKey := []byte(fmt.Sprintf(symKeyJSONTemplate,
+			symKeyMaterialType,
+			base64.StdEncoding.EncodeToString(e4crypto.RandomKey()[1:]),
+		))
+
+		_, err := FromRawJSON(jsonKey)
+		if err == nil {
+			t.Fatal("An error was expected while unmarshalling symkey")
 		}
 	})
 }

--- a/keys/publickey.go
+++ b/keys/publickey.go
@@ -240,24 +240,18 @@ func (k *pubKeyMaterial) SetKey(key []byte) error {
 	copy(sk, key)
 
 	k.PrivateKey = sk
-	if err := k.updateSharedKey(); err != nil {
-		return err
-	}
 
-	return nil
+	return k.updateSharedKey()
 }
 
-func (k *pubKeyMaterial) SetC2PubKey(c2PubKey e4crypto.Curve25519PublicKey) error {
-	if err := e4crypto.ValidateCurve25519PubKey(c2PubKey); err != nil {
+func (k *pubKeyMaterial) SetC2PubKey(newC2PubKey e4crypto.Curve25519PublicKey) error {
+	if err := e4crypto.ValidateCurve25519PubKey(newC2PubKey); err != nil {
 		return err
 	}
 
-	k.C2PubKey = c2PubKey
-	if err := k.updateSharedKey(); err != nil {
-		return err
-	}
+	k.C2PubKey = newC2PubKey
 
-	return nil
+	return k.updateSharedKey()
 }
 
 // MarshalJSON  will infer the key type in the marshalled json data

--- a/keys/publickey.go
+++ b/keys/publickey.go
@@ -305,3 +305,30 @@ func (k *pubKeyMaterial) updateSharedKey() error {
 
 	return nil
 }
+
+func (k *pubKeyMaterial) validate() error {
+	if err := e4crypto.ValidateID(k.SignerID); err != nil {
+		return err
+	}
+	if err := e4crypto.ValidateEd25519PrivKey(k.PrivateKey); err != nil {
+		return err
+	}
+	if err := e4crypto.ValidateCurve25519PubKey(k.C2PubKey); err != nil {
+		return err
+	}
+	for id, pubKey := range k.PubKeys {
+		decodedID, err := hex.DecodeString(id)
+		if err != nil {
+			return err
+		}
+
+		if err := e4crypto.ValidateID(decodedID); err != nil {
+			return err
+		}
+		if err := e4crypto.ValidateEd25519PubKey(pubKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/keys/publickey.go
+++ b/keys/publickey.go
@@ -43,7 +43,8 @@ type pubKeyMaterial struct {
 	C2PubKey   e4crypto.Curve25519PublicKey `json:"c2PubKey,omitempty"`
 	PubKeys    map[string]ed25519.PublicKey `json:"pubKeys,omitempty"`
 
-	mutex sync.RWMutex
+	mutex     sync.RWMutex
+	sharedKey []byte
 }
 
 var _ PubKeyMaterial = (*pubKeyMaterial)(nil)
@@ -63,20 +64,24 @@ func NewPubKeyMaterial(signerID []byte, privateKey ed25519.PrivateKey, c2PubKey 
 		return nil, fmt.Errorf("invalid c2 public key: %v", err)
 	}
 
-	e := &pubKeyMaterial{
+	k := &pubKeyMaterial{
 		PubKeys: make(map[string]ed25519.PublicKey),
 	}
 
-	e.C2PubKey = make([]byte, len(c2PubKey))
-	copy(e.C2PubKey, c2PubKey)
+	k.C2PubKey = make([]byte, len(c2PubKey))
+	copy(k.C2PubKey, c2PubKey)
 
-	e.PrivateKey = make([]byte, len(privateKey))
-	copy(e.PrivateKey, privateKey)
+	k.PrivateKey = make([]byte, len(privateKey))
+	copy(k.PrivateKey, privateKey)
 
-	e.SignerID = make([]byte, len(signerID))
-	copy(e.SignerID, signerID)
+	if err := k.updateSharedKey(); err != nil {
+		return nil, err
+	}
 
-	return e, nil
+	k.SignerID = make([]byte, len(signerID))
+	copy(k.SignerID, signerID)
+
+	return k, nil
 }
 
 // NewRandomPubKeyMaterial creates a new PubKeyMaterial key from a random ed25519 key
@@ -152,16 +157,11 @@ func (k *pubKeyMaterial) UnprotectMessage(protected []byte, topicKey TopicKey) (
 // UnprotectCommand attempt to decrypt a client command from the given protected cipher.
 // It will use the material's private key and the c2 public key to create the required symmetric key
 func (k *pubKeyMaterial) UnprotectCommand(protected []byte) ([]byte, error) {
-	// convert ed key to curve key
-	curvePrivateKey := e4crypto.PrivateEd25519KeyToCurve25519(k.PrivateKey)
-	shared, err := curve25519.X25519(curvePrivateKey, k.C2PubKey)
-	if err != nil {
-		return nil, fmt.Errorf("curve25519 X25519 failed: %v", err)
+	if err := e4crypto.ValidateSymKey(k.sharedKey); err != nil {
+		return nil, fmt.Errorf("invalid shared key: %v", err)
 	}
 
-	key := e4crypto.Sha3Sum256(shared[:])[:e4crypto.KeyLen]
-
-	return e4crypto.UnprotectSymKey(protected, key)
+	return e4crypto.UnprotectSymKey(protected, k.sharedKey)
 }
 
 // AddPubKey store the given id and key in internal storage
@@ -240,6 +240,22 @@ func (k *pubKeyMaterial) SetKey(key []byte) error {
 	copy(sk, key)
 
 	k.PrivateKey = sk
+	if err := k.updateSharedKey(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *pubKeyMaterial) SetC2PubKey(c2PubKey e4crypto.Curve25519PublicKey) error {
+	if err := e4crypto.ValidateCurve25519PubKey(c2PubKey); err != nil {
+		return err
+	}
+
+	k.C2PubKey = c2PubKey
+	if err := k.updateSharedKey(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -276,4 +292,16 @@ func (k *pubKeyMaterial) PublicKey() ed25519.PublicKey {
 	}
 
 	return publicKey
+}
+
+func (k *pubKeyMaterial) updateSharedKey() error {
+	curvePrivateKey := e4crypto.PrivateEd25519KeyToCurve25519(k.PrivateKey)
+	sharedKey, err := curve25519.X25519(curvePrivateKey, k.C2PubKey)
+	if err != nil {
+		return fmt.Errorf("curve25519 X25519 failed: %v", err)
+	}
+
+	k.sharedKey = e4crypto.Sha3Sum256(sharedKey)[:e4crypto.KeyLen]
+
+	return nil
 }

--- a/keys/publickey_test.go
+++ b/keys/publickey_test.go
@@ -399,7 +399,7 @@ func TestPubKeyMaterialMarshalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate public key: %v", err)
 	}
-	if err := k.AddPubKey([]byte("id1"), pk1); err != nil {
+	if err := k.AddPubKey(e4crypto.HashIDAlias("id1"), pk1); err != nil {
 		t.Fatalf("Failed to add pubkey for id1: %v", err)
 	}
 
@@ -407,7 +407,7 @@ func TestPubKeyMaterialMarshalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate public key: %v", err)
 	}
-	if err := k.AddPubKey([]byte("id2"), pk2); err != nil {
+	if err := k.AddPubKey(e4crypto.HashIDAlias("id2"), pk2); err != nil {
 		t.Fatalf("Failed to add pubkey for id2: %v", err)
 	}
 

--- a/keys/publickey_test.go
+++ b/keys/publickey_test.go
@@ -425,3 +425,65 @@ func TestPubKeyMaterialMarshalJSON(t *testing.T) {
 		t.Fatalf("Invalid unmarshalled key: got %v, wanted %v", unmarshalledKey, k)
 	}
 }
+
+func TestPrecomputeSharedKey(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+
+	clientID := e4crypto.HashIDAlias("test")
+	c2Pk := getTestC2PubKey(t)
+
+	k, err := NewPubKeyMaterial(clientID, privateKey, c2Pk)
+	if err != nil {
+		t.Fatalf("Failed to create pubKeyMaterial: %v", err)
+	}
+
+	typedKey, ok := k.(*pubKeyMaterial)
+	if !ok {
+		t.Fatalf("failed to cast key to pubKeyMaterial")
+	}
+
+	if len(typedKey.sharedKey) == 0 {
+		t.Fatalf("Expected sharedKey to have length > 0")
+	}
+
+	if !bytes.Equal(typedKey.C2PubKey, c2Pk) {
+		t.Fatalf("Expected C2 pubkey to be %v, got %v", c2Pk, typedKey.C2PubKey)
+	}
+
+	originalSharedKey := make([]byte, len(typedKey.sharedKey))
+	copy(originalSharedKey, typedKey.sharedKey)
+
+	newC2Pk := getTestC2PubKey(t)
+	if err := typedKey.SetC2PubKey(newC2Pk); err != nil {
+		t.Fatalf("failed to set key: %v", err)
+	}
+
+	if !bytes.Equal(typedKey.C2PubKey, newC2Pk) {
+		t.Fatalf("Expected new C2 pubkey to be %v, got %v", newC2Pk, typedKey.C2PubKey)
+	}
+
+	if bytes.Equal(typedKey.sharedKey, originalSharedKey) {
+		t.Fatal("Expected shared key to change when c2 key is changed")
+	}
+
+	copy(originalSharedKey, typedKey.sharedKey)
+
+	_, newPrivateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+
+	if err := typedKey.SetKey(newPrivateKey); err != nil {
+		t.Fatalf("failed to set key: %v", err)
+	}
+
+	if !bytes.Equal(typedKey.PrivateKey, newPrivateKey) {
+		t.Fatalf("Expected new private key to be %v, got %v", newPrivateKey, typedKey.PrivateKey)
+	}
+	if bytes.Equal(typedKey.sharedKey, originalSharedKey) {
+		t.Fatal("Expected shared key to change when private key is changed")
+	}
+}

--- a/keys/symmetric.go
+++ b/keys/symmetric.go
@@ -104,3 +104,7 @@ func (k *symKeyMaterial) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(jsonKey)
 }
+
+func (k *symKeyMaterial) validate() error {
+	return e4crypto.ValidateSymKey(k.Key)
+}

--- a/keys/types.go
+++ b/keys/types.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 
 	"golang.org/x/crypto/ed25519"
+
+	e4crypto "github.com/teserakt-io/e4go/crypto"
 )
 
 var (
@@ -70,4 +72,6 @@ type PubKeyStore interface {
 	RemovePubKey(id []byte) error
 	// ResetPubKeys removes all public keys stored.
 	ResetPubKeys()
+	// SetC2PubKey replace the C2 public key by the given one.
+	SetC2PubKey(c2PubKey e4crypto.Curve25519PublicKey) error
 }

--- a/keys/types.go
+++ b/keys/types.go
@@ -52,6 +52,10 @@ type KeyMaterial interface {
 	SetKey(key []byte) error
 	// MarshalJSON marshal the key material into json
 	MarshalJSON() ([]byte, error)
+
+	// validate performs a keyMaterial validation,
+	// and returns an error when anything is invalid.
+	validate() error
 }
 
 // PubKeyStore interface defines methods to interact with a public key storage

--- a/keys/types.go
+++ b/keys/types.go
@@ -76,6 +76,6 @@ type PubKeyStore interface {
 	RemovePubKey(id []byte) error
 	// ResetPubKeys removes all public keys stored.
 	ResetPubKeys()
-	// SetC2PubKey replace the C2 public key by the given one.
+	// SetC2PubKey replaces the current C2 public key with the newly transmitted one.
 	SetC2PubKey(c2PubKey e4crypto.Curve25519PublicKey) error
 }


### PR DESCRIPTION
Added shared key computation when:
- creating the public key material
- restoring a saved public key material
- changing the c2 key (via SetC2Key command)
- changing private key (via SetIDKey command)

Updated UnprotectCommand to use the shared key instead of calculating it on each commands.

Added new SetC2Key command support
Added more tests and checks when loading a saved client

Fix #34 