### PR TITLE
Replaced ErrToShortCipher with ErrTooShortCipherText.

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -31,8 +31,8 @@ import (
 var (
 	// ErrInvalidProtectedLen occurs when the protected message is  not of the expected length
 	ErrInvalidProtectedLen = errors.New("invalid length of protected message")
-	// ErrTooShortCipher occurs when trying to unprotect a cipher shorter than TimestampLen
-	ErrTooShortCipher = errors.New("ciphertext too short")
+	// ErrTooShortCiphertext occurs when trying to unprotect a ciphertext shorter than TimestampLen
+	ErrTooShortCiphertext = errors.New("ciphertext too short")
 	// ErrTimestampInFuture occurs when the cipher timestamp is in the future
 	ErrTimestampInFuture = errors.New("timestamp received is in the future")
 	// ErrTimestampTooOld occurs when the cipher timestamp is older than MaxDelayDuration from now
@@ -151,7 +151,7 @@ func ProtectSymKey(payload, key []byte) ([]byte, error) {
 // UnprotectSymKey attempt to decrypt protected bytes, using given symmetric key
 func UnprotectSymKey(protected, key []byte) ([]byte, error) {
 	if len(protected) <= TimestampLen+TagLen {
-		return nil, ErrTooShortCipher
+		return nil, ErrTooShortCiphertext
 	}
 
 	ct := protected[TimestampLen:]

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -239,8 +239,8 @@ func TestProtectUnprotectSymKey(t *testing.T) {
 	// Too short cipher are not allowed
 	tooShortProtected := make([]byte, TimestampLen)
 	_, err = UnprotectSymKey(tooShortProtected, key)
-	if err != ErrTooShortCipher {
-		t.Fatalf("Invalid error, got: %v, wanted: %v", err, ErrTooShortCipher)
+	if err != ErrTooShortCiphertext {
+		t.Fatalf("Invalid error, got: %v, wanted: %v", err, ErrTooShortCiphertext)
 	}
 
 	if _, err := UnprotectSymKey(protected, []byte("not a key")); err == nil {


### PR DESCRIPTION
Fix #37.