### PR TITLE
Added missing support for ed25519 key sizes on SetIDKey command

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -320,12 +320,12 @@ func TestProtectUnprotectCommandsPubKey(t *testing.T) {
 	}
 
 	command := []byte{0x05}
-	sharedKeyKey, err := curve25519.X25519(c2PrivateCurveKey, e4crypto.PublicEd25519KeyToCurve25519(clientEdPk))
+	sharedPoint, err := curve25519.X25519(c2PrivateCurveKey, e4crypto.PublicEd25519KeyToCurve25519(clientEdPk))
 	if err != nil {
 		t.Fatalf("curve25519 X25519 failed: %v", err)
 	}
 
-	protected, err := e4crypto.ProtectSymKey(command, e4crypto.Sha3Sum256(sharedKeyKey))
+	protected, err := e4crypto.ProtectSymKey(command, e4crypto.Sha3Sum256(sharedPoint))
 	if err != nil {
 		t.Fatalf("ProtectSymKey failed: %v", err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -78,7 +78,7 @@ func processCommand(client Client, payload []byte) error {
 		return client.resetTopics()
 
 	case SetIDKey:
-		if len(blob) != e4crypto.KeyLen {
+		if len(blob) != e4crypto.KeyLen && len(blob) != ed25519.PrivateKeySize {
 			return errors.New("invalid SetIDKey length")
 		}
 		return client.setIDKey(blob)
@@ -136,8 +136,9 @@ func CmdResetTopics() ([]byte, error) {
 
 // CmdSetIDKey creates a command to set the client private key to the given key
 func CmdSetIDKey(key []byte) ([]byte, error) {
-	if keyLen := len(key); keyLen != e4crypto.KeyLen {
-		return nil, fmt.Errorf("invalid key length, got %d, wanted %d", keyLen, e4crypto.KeyLen)
+	keyLen := len(key)
+	if keyLen != e4crypto.KeyLen && keyLen != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid key length, got %d, wanted %d or %d", keyLen, e4crypto.KeyLen, ed25519.PrivateKeySize)
 	}
 
 	cmd := append([]byte{SetIDKey}, key...)

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c/go.mod h1:X
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=

--- a/go.sum
+++ b/go.sum
@@ -29,7 +29,6 @@ github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c/go.mod h1:X
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d h1:9FCpayM9Egr1baVnV1SX0H87m+XB0B8S0hAMi99X/3U=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=


### PR DESCRIPTION
CmdSetIDKey and processCommand were enforcing key size of 32 bytes, which caused processing on this command in pubkey mode to fail when receiving a 64 bytes ed25519 private key.

Those methods now accept both 32 and 64 bytes keys. The exact length required is still checked further down in the KeyMaterial.SetKey()  so it is not possible to pass an ed25519 key to a symmetric key client, or the opposite around.

Have also added a bunch of tests to check all the commands against a pubkey client