### PR TITLE
Keygen - truncate target file on open

### DIFF
--- a/cmd/e4keygen/e4keygen.go
+++ b/cmd/e4keygen/e4keygen.go
@@ -98,7 +98,7 @@ func writeKey(privateBytes []byte, publicBytes []byte, filepath string, force bo
 }
 
 func write(keyBytes []byte, filepath string, perm os.FileMode, force bool) error {
-	openFlags := os.O_CREATE | os.O_WRONLY
+	openFlags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	if !force {
 		openFlags = openFlags | os.O_EXCL
 	}


### PR DESCRIPTION
When using -force on the keygen, and if the target file already contains data, the actual keygen doesn't truncate the additional data, resulting in invalid key in the output file.

for example:
```
 $ echo "tooMuchDataForAPublicKeytooMuchDataForAPublicKey" > testCurve1.pub
 $ hexdump -C testCurve1.pub 
00000000  74 6f 6f 4d 75 63 68 44  61 74 61 46 6f 72 41 50  |tooMuchDataForAP|
00000010  75 62 6c 69 63 4b 65 79  74 6f 6f 4d 75 63 68 44  |ublicKeytooMuchD|
00000020  61 74 61 46 6f 72 41 50  75 62 6c 69 63 4b 65 79  |ataForAPublicKey|
00000030  0a                                                |.|
00000031
 $ ./bin/e4keygen -force -out testCurve1 -type curve25519
private key successfully written at testCurve1
public key successfully written at testCurve1.pub
 $ hexdump -C testCurve1.pub 
00000000  b3 79 5e 06 3b 48 f9 85  bc ed c3 47 d6 ed db a4  |.y^.;H.....G....|
00000010  ad 81 41 b5 bd 15 d0 36  4c c4 b0 99 19 10 51 71  |..A....6L.....Qq|
00000020  61 74 61 46 6f 72 41 50  75 62 6c 69 63 4b 65 79  |ataForAPublicKey|
00000030  0a                                                |.|
00000031
```

This fix ensure the file is truncated before dumping the key in it.

